### PR TITLE
Add Clone trait to Keycode

### DIFF
--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 /// A list of supported keys that we can query from the OS. Outside of mod
 /// keys, we only support English keys at the moment.
 pub enum Keycode {


### PR DESCRIPTION
Ease the result value usage to avoid use after move.

The following will be failed, I found no workaround.

```
stream.write(&[ key as u8 ]).unwrap(); // Move occurs, thus compile failed!
println!("Pressed: {:?}", key);
```

But with `Clone` trait, the value can be cloned to be written on the stream: `key.clone() as u8`.