### PR TITLE
Fixing memory leak from not freeing memory from XGetKeyboardMapping

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -96,6 +96,9 @@ impl DeviceState {
                                 None => (),
                             }
                         }
+
+                        // Free the memory allocated by XGetKeyboardMapping.
+                        xlib::XFree(keysym as *mut std::ffi::c_void);
                     }
                 }
             }


### PR DESCRIPTION
Fixes the memory leak reported in #8.