### PR TITLE
Add macos support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,7 @@ features = ["xlib"]
 [target.'cfg(target_os = "windows")'.dependencies]
 user32-sys = "0.2.0"
 winapi = "0.2.8"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+readkey = "0.1.7"
+readmouse = "0.2.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/ostrosco/device_query.svg?branch=master)](https://travis-ci.org/ostrosco/device_query)
 
-A simple library to query mouse and keyboard inputs on demand without a window. Will work in Windows and Linux.
+A simple library to query mouse and keyboard inputs on demand without a window. Will work in Windows, Linux, and macOS.
 
 ```Rust
 use device_query::{DeviceQuery, DeviceState, MouseState, Keycode};

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,9 @@ extern crate pkg_config;
 #[cfg(target_os = "windows")]
 fn main() {}
 
+#[cfg(target_os = "macos")]
+fn main() {}
+
 #[cfg(target_os = "linux")]
 use std::env;
 #[cfg(target_os = "linux")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! A simple library for querying mouse and keyboard state without requiring
-//! an active window. Currently works in Windows and Linux.
+//! an active window. Currently works in Windows, Linux, and macOS.
 //!
 //! ```no-run
 //! use device_query::{DeviceQuery, DeviceState, MouseState, Keycode};
@@ -25,6 +25,11 @@ pub use linux::DeviceState;
 mod windows;
 #[cfg(target_os = "windows")]
 pub use windows::DeviceState;
+
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "macos")]
+pub use macos::DeviceState;
 
 pub trait DeviceQuery {
     fn get_mouse(&self) -> MouseState;

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -1,0 +1,92 @@
+use keymap::Keycode;
+use mouse_state::MouseState;
+
+pub struct DeviceState;
+
+const MAPPING: &[(readkey::Keycode, Keycode)] = &[
+    (readkey::Keycode::_0, Keycode::Key0),
+    (readkey::Keycode::_1, Keycode::Key1),
+    (readkey::Keycode::_2, Keycode::Key2),
+    (readkey::Keycode::_3, Keycode::Key3),
+    (readkey::Keycode::_4, Keycode::Key4),
+    (readkey::Keycode::_5, Keycode::Key5),
+    (readkey::Keycode::_6, Keycode::Key6),
+    (readkey::Keycode::_7, Keycode::Key7),
+    (readkey::Keycode::_8, Keycode::Key8),
+    (readkey::Keycode::_9, Keycode::Key9),
+    (readkey::Keycode::A, Keycode::A),
+    (readkey::Keycode::B, Keycode::B),
+    (readkey::Keycode::C, Keycode::C),
+    (readkey::Keycode::D, Keycode::D),
+    (readkey::Keycode::E, Keycode::E),
+    (readkey::Keycode::F, Keycode::F),
+    (readkey::Keycode::G, Keycode::G),
+    (readkey::Keycode::H, Keycode::H),
+    (readkey::Keycode::I, Keycode::I),
+    (readkey::Keycode::J, Keycode::J),
+    (readkey::Keycode::K, Keycode::K),
+    (readkey::Keycode::L, Keycode::L),
+    (readkey::Keycode::M, Keycode::M),
+    (readkey::Keycode::N, Keycode::N),
+    (readkey::Keycode::O, Keycode::O),
+    (readkey::Keycode::P, Keycode::P),
+    (readkey::Keycode::Q, Keycode::Q),
+    (readkey::Keycode::R, Keycode::R),
+    (readkey::Keycode::S, Keycode::S),
+    (readkey::Keycode::T, Keycode::T),
+    (readkey::Keycode::U, Keycode::U),
+    (readkey::Keycode::V, Keycode::V),
+    (readkey::Keycode::W, Keycode::W),
+    (readkey::Keycode::X, Keycode::X),
+    (readkey::Keycode::Y, Keycode::Y),
+    (readkey::Keycode::Z, Keycode::Z),
+    (readkey::Keycode::F1, Keycode::F1),
+    (readkey::Keycode::F2, Keycode::F2),
+    (readkey::Keycode::F3, Keycode::F3),
+    (readkey::Keycode::F4, Keycode::F4),
+    (readkey::Keycode::F5, Keycode::F5),
+    (readkey::Keycode::F6, Keycode::F6),
+    (readkey::Keycode::F7, Keycode::F7),
+    (readkey::Keycode::F8, Keycode::F8),
+    (readkey::Keycode::F9, Keycode::F9),
+    (readkey::Keycode::F10, Keycode::F10),
+    (readkey::Keycode::F11, Keycode::F11),
+    (readkey::Keycode::F12, Keycode::F12),
+    (readkey::Keycode::Escape, Keycode::Escape),
+    (readkey::Keycode::Space, Keycode::Space),
+    (readkey::Keycode::Control, Keycode::LControl),
+    (readkey::Keycode::RightControl, Keycode::RControl),
+    (readkey::Keycode::Shift, Keycode::LShift),
+    (readkey::Keycode::RightShift, Keycode::RShift),
+    (readkey::Keycode::Option, Keycode::LAlt),
+    (readkey::Keycode::RightOption, Keycode::RAlt),
+    (readkey::Keycode::Return, Keycode::Enter),
+];
+
+impl DeviceState {
+    pub fn new() -> DeviceState {
+        DeviceState {}
+    }
+
+    pub fn query_pointer(&self) -> MouseState {
+        let (x, y) = readmouse::Mouse::location();
+        let button_pressed = vec![
+            false,
+            readmouse::Mouse::Left.is_pressed(),
+            readmouse::Mouse::Right.is_pressed(),
+            readmouse::Mouse::Center.is_pressed(),
+            false,
+        ];
+        MouseState {
+            coords: (x as i32, y as i32),
+            button_pressed,
+        }
+    }
+    pub fn query_keymap(&self) -> Vec<Keycode> {
+        MAPPING
+            .iter()
+            .filter(|(from, _)| from.is_pressed())
+            .map(|(_, to)| to.clone())
+            .collect()
+    }
+}


### PR DESCRIPTION
This adds support for reading the keyboard and mouse on macOS. It compiles and executes successfully on my Macbook Air running macOS Catalina.