### PR TITLE
Removing call of XInitThreads on Linux bindings

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -14,7 +14,6 @@ pub struct DeviceState {
 impl DeviceState {
     pub fn new() -> DeviceState {
         unsafe {
-            xlib::XInitThreads();
             let disp = xlib::XOpenDisplay(ptr::null());
             DeviceState { display: disp }
         }


### PR DESCRIPTION
- Calling XInitThreads can cause problems if it's already been called or
  if any other library is working with Xlib. The library shouldn't be
  responsible for this anyways, so it's being removed.

Fixes #18.