### PR TITLE
Use c_char instead of i8 for XQueryKeymap

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -4,6 +4,7 @@ extern crate x11;
 use keymap::Keycode;
 use linux::x11::xlib;
 use mouse_state::MouseState;
+use std::os::raw::c_char;
 use std::ptr;
 use std::slice;
 
@@ -73,7 +74,7 @@ impl DeviceState {
     pub fn query_keymap(&self) -> Vec<Keycode> {
         let mut keycodes = vec![];
         unsafe {
-            let keymap: *mut i8 = [0; 32].as_mut_ptr();
+            let keymap: *mut c_char = [0; 32].as_mut_ptr();
             xlib::XQueryKeymap(self.display, keymap);
             for (ix, byte) in
                 slice::from_raw_parts(keymap, 32).iter().enumerate()


### PR DESCRIPTION
Hey,
I was trying to compile my [project](https://github.com/orhun/menyoki) (which depends on device_query) on ARM (`arm-unknown-linux-gnueabihf`) and got this:

```sh
error[E0308]: mismatched types
  --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/device_query-0.2.6/src/linux/mod.rs:77:46
   |
77 |             xlib::XQueryKeymap(self.display, keymap);
   |                                              ^^^^^^ expected `u8`, found `i8`
   |
   = note: expected raw pointer `*mut u8`
              found raw pointer `*mut i8`
```

I looked up the [XQueryKeymap](https://docs.rs/x11/2.18.2/x11/xlib/fn.XQueryKeymap.html) function and saw that it takes a [c_char](https://doc.rust-lang.org/nightly/std/os/raw/type.c_char.html) as the 2nd argument:

```rust
pub unsafe extern "C" fn XQueryKeymap(
    _2: *mut Display, 
    _1: *mut c_char
) -> c_int
```

And when you check the c_char type, it says:

```
This type will always be either i8 or u8, as the type is defined as being one byte long.
```

So basically `keymap` variable being a hardcoded `*mut i8` might raise a problem on ARM architecture since the type can be `u8` as well.

This PR changes `*mut i8` type to `*mut c_char` for building `device_query` on ARM. (further testing might be required regarding to that)