### PR TITLE
fix #22: panic on initialization failure on Linux

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -22,9 +22,8 @@ impl DeviceState {
     pub fn new() -> DeviceState {
         unsafe {
             let display = xlib::XOpenDisplay(ptr::null());
-            match display.as_ref() {
-                Some(_) => (),
-                None => panic!("Could not connect to a X display")
+            if display.as_ref().is_none() {
+                panic!("Could not connect to a X display");
             }
             DeviceState { display }
         }

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -21,8 +21,12 @@ impl Default for DeviceState {
 impl DeviceState {
     pub fn new() -> DeviceState {
         unsafe {
-            let disp = xlib::XOpenDisplay(ptr::null());
-            DeviceState { display: disp }
+            let display = xlib::XOpenDisplay(ptr::null());
+            match display.as_ref() {
+                Some(_) => (),
+                None => panic!("Could not connect to a X display")
+            }
+            DeviceState { display }
         }
     }
 


### PR DESCRIPTION
Add a clear panic message of initialization failure on Linux to prevent the segmentation fault.

When using `XOpenDisplay`, on rare occasions it will return a NULL pointer (the main one being no X display, like in WSL in issue #22). This NULL would later be used in other functions, which would cause a segmentation fault.

The PR prevents the segmentation fault by panicking early with a clear reason of failure. It basically checks for the NULL pointer by obtaining an `Option` with a reference. This `Option` will be `None` if the pointer is NULL.