### PR TITLE
Fix some problems

### DIFF
--- a/src/device_state/linux/mod.rs
+++ b/src/device_state/linux/mod.rs
@@ -8,7 +8,7 @@ use std::os::raw::c_char;
 use std::ptr;
 use std::slice;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 /// Device state descriptor.
 pub struct DeviceState {
     display: *mut xlib::Display,
@@ -17,6 +17,14 @@ pub struct DeviceState {
 impl Default for DeviceState {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl Drop for DeviceState {
+    fn drop(&mut self) {
+        unsafe {
+            xlib::XCloseDisplay(self.display);
+        }
     }
 }
 

--- a/src/device_state/windows/mod.rs
+++ b/src/device_state/windows/mod.rs
@@ -2,9 +2,9 @@ extern crate winapi;
 
 use keymap::Keycode;
 use mouse_state::MouseState;
-use windows::winapi::shared::windef::POINT;
-use windows::winapi::um::winuser;
-use windows::winapi::um::winuser::{GetAsyncKeyState, GetCursorPos};
+use self::winapi::shared::windef::POINT;
+use self::winapi::um::winuser;
+use self::winapi::um::winuser::{GetAsyncKeyState, GetCursorPos};
 
 pub struct DeviceState;
 


### PR DESCRIPTION
- Fix the broken build in windows because of wrong reference to winapi
- Fix the problem that device_query could be panicked with following message when trying to get new display because `Drop `trait is not defined for `DeviceState`
`Maximum number of clients reached...`