### PR TITLE
Enable checking and prompting for required MacOS permissions to use this crate in an app

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ winapi = { version = "0.3.9", features = ["winuser"]}
 [target.'cfg(target_os = "macos")'.dependencies]
 readkey = "0.1.7"
 readmouse = "0.2.0"
+macos-accessibility-client = "0.0.1"

--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ backspace, et cetera. This is due to a permission issue. To work around this:
 
 * open the MacOS system preferences
 * go to Security -> Privacy
-* scroll down to Accessbility and unlock it
+* scroll down to Accessibility and unlock it
 * add the app that is using `device_query` (such as your terminal) to the list

--- a/src/device_state/linux/mod.rs
+++ b/src/device_state/linux/mod.rs
@@ -14,12 +14,6 @@ pub struct DeviceState {
     display: *mut xlib::Display,
 }
 
-impl Default for DeviceState {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Drop for DeviceState {
     fn drop(&mut self) {
         unsafe {

--- a/src/device_state/macos/mod.rs
+++ b/src/device_state/macos/mod.rs
@@ -1,3 +1,5 @@
+extern crate macos_accessibility_client;
+
 use keymap::Keycode;
 use mouse_state::MouseState;
 
@@ -104,6 +106,9 @@ const MAPPING: &[(readkey::Keycode, Keycode)] = &[
 
 impl DeviceState {
     pub fn new() -> DeviceState {
+        // TODO: remove this
+        assert!(has_accessibility(), "This app does not have Accessibility Permissions enabled and will not work");
+
         DeviceState {}
     }
 
@@ -116,11 +121,13 @@ impl DeviceState {
             readmouse::Mouse::Center.is_pressed(),
             false,
         ];
+
         MouseState {
             coords: (x as i32, y as i32),
             button_pressed,
         }
     }
+
     pub fn query_keymap(&self) -> Vec<Keycode> {
         MAPPING
             .iter()
@@ -128,4 +135,22 @@ impl DeviceState {
             .map(|(_, to)| *to)
             .collect()
     }
+}
+
+/// Returns true if the Accessibility permissions necessary for this library to work are granted
+/// to this process
+///
+/// If this returns false, the app can request them through the OS APIs, or the user can:
+///   1. open the MacOS system preferences
+///   2. go to Security -> Privacy
+///   3. scroll down to Accessibility and unlock it
+///   4. Add the app that is using device_query (such as your terminal) to the list
+///
+fn has_accessibility() -> bool {
+    use self::macos_accessibility_client::accessibility::*;
+    // Without prompting:
+    // application_is_trusted()
+
+    // With prompting:
+    application_is_trusted_with_prompt()
 }

--- a/src/device_state/macos/mod.rs
+++ b/src/device_state/macos/mod.rs
@@ -125,7 +125,7 @@ impl DeviceState {
         MAPPING
             .iter()
             .filter(|(from, _)| from.is_pressed())
-            .map(|(_, to)| to.clone())
+            .map(|(_, to)| *to)
             .collect()
     }
 }

--- a/src/device_state/mod.rs
+++ b/src/device_state/mod.rs
@@ -14,3 +14,9 @@ pub use self::windows::DeviceState;
 mod macos;
 #[cfg(target_os = "macos")]
 pub use self::macos::DeviceState;
+
+impl Default for DeviceState {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/device_state/windows/mod.rs
+++ b/src/device_state/windows/mod.rs
@@ -2,6 +2,7 @@ extern crate winapi;
 
 use keymap::Keycode;
 use mouse_state::MouseState;
+
 use self::winapi::shared::windef::POINT;
 use self::winapi::um::winuser;
 use self::winapi::um::winuser::{GetAsyncKeyState, GetCursorPos};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,14 +5,20 @@
 //! use device_query::{DeviceQuery, DeviceState, MouseState, Keycode};
 //!
 //! let device_state = DeviceState::new();
+//!
 //! let mouse: MouseState = device_state.get_mouse();
 //! println!("Current Mouse Coordinates: {:?}", mouse.coords);
+//!
 //! let keys: Vec<Keycode> = device_state.get_keys();
 //! println!("Is A pressed? {}", keys.contains(&Keycode::A));
 //! ```
+//!
 //! It's also possible to listen for events.
 //! ```no_run
+//!  use device_query::{DeviceEvents, DeviceState};
+//!
 //!  let device_state = DeviceState::new();
+//!
 //!  let _guard = device_state.on_mouse_move(|position| {
 //!     println!("Mouse position: {:#?}", position);
 //!  });
@@ -27,7 +33,8 @@
 //!  });
 //!  let _guard = device_state.on_key_up(|key| {
 //!     println!("Keyboard key up: {:#?}", key);
-//!  });//!
+//!  });
+//!
 //!  loop {}
 //! ```
 


### PR DESCRIPTION
This change lays the ground work to expose "doesn't have permission to work on MacOS at all" through the API. As-is, it asserts and fails loudly until you give the app permissions.

Here's what a fresh MacOS build will look like to a new user *as is*:
<img width="554" alt="image" src="https://user-images.githubusercontent.com/1052157/151683313-ff0fcf32-7109-41e7-8531-c0edb7964b4f.png">

This is much better than the current "silently don't do the crate's raison d'être", but not ideal. But the ground work here has been laid, so we just need to sort out what the API could look like! This relates to #44.

An important point to note: This depends on a crate that's razor thin, it just links to OS APIs, but is listed at version 0.0.1. This is less than ideal but it's pretty basic code that could be ported into this crate instead, if this is an issue.

I also made some minor changes reported by clippy and related things. I think these are only issues because clippy isn't run on MacOS as part of CI.