### PR TITLE
make MouseState clone and make DeviceState consistent across platforms

### DIFF
--- a/src/device_state/macos/mod.rs
+++ b/src/device_state/macos/mod.rs
@@ -3,6 +3,7 @@ extern crate macos_accessibility_client;
 use keymap::Keycode;
 use mouse_state::MouseState;
 
+#[derive(Debug, Clone)]
 pub struct DeviceState;
 
 const MAPPING: &[(readkey::Keycode, Keycode)] = &[

--- a/src/device_state/windows/mod.rs
+++ b/src/device_state/windows/mod.rs
@@ -7,6 +7,7 @@ use self::winapi::shared::windef::POINT;
 use self::winapi::um::winuser;
 use self::winapi::um::winuser::{GetAsyncKeyState, GetCursorPos};
 
+#[derive(Debug, Clone)]
 pub struct DeviceState;
 
 impl DeviceState {

--- a/src/mouse_state.rs
+++ b/src/mouse_state.rs
@@ -6,7 +6,7 @@ pub type MousePosition = (i32, i32);
 /// MouseButton.
 pub type MouseButton = usize;
 
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, PartialEq, Default, Clone)]
 /// A simple structure containing the current mouse coordinates and the
 /// state of each mouse button that we can query. Currently, Windows and
 /// Linux provide nice ways to query five mouse buttons. Since button


### PR DESCRIPTION
I think it would be easier to copy around `MouseState` if it was `Copy`.
as we only expose 5 buttons atm,  `MouseState.button_pressed` which is `Vec<bool>` right now, into `[bool; 6]` and it will be a very lightweight struct. 

ofcourse, we can also use [`static_vec` ](https://crates.io/crates/smallvec) (though overkill).

 but as `MouseState.button_pressed` field is public, i didn't want to change it before asking you.

Instead, I made it `Clone` which it should have been anyway.