### PR TITLE
added Eq and Hash derived impls for Keycode

### DIFF
--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::str::FromStr;
 
 /// A list of supported keys that we can query from the OS. Outside of mod.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
 #[allow(missing_docs)]
 pub enum Keycode {
     Key0,


### PR DESCRIPTION
Hi!

I'm not aware of any downsides to adding these derived traits to the `Keycode` enum.

I came across a use case in a personal project that requires these, and Rust's orphan trait rules prevent me from adding the derivations in my own project.

Let me know what you think!