### PR TITLE
api: add `DeviceState::checked_new` to avoid panic when creating a new DeviceState

### DIFF
--- a/src/device_state/macos/mod.rs
+++ b/src/device_state/macos/mod.rs
@@ -113,6 +113,15 @@ impl DeviceState {
         DeviceState {}
     }
 
+    /// returns `None` if app doesn't accessibility permissions.
+    pub fn checked_new() -> Option<DeviceState> {
+        if has_accessibility() {
+            Some(DeviceState {})
+        } else {
+            None
+        }
+    }
+
     pub fn query_pointer(&self) -> MouseState {
         let (x, y) = readmouse::Mouse::location();
         let button_pressed = vec![


### PR DESCRIPTION
I didn't want to panic if my app didn't have accessibility permissions. I didn't want to break the API either so i added a new function.