### PR TITLE
added macro use_keys!

### DIFF
--- a/src/device_state/macos/mod.rs
+++ b/src/device_state/macos/mod.rs
@@ -167,3 +167,23 @@ fn has_accessibility() -> bool {
     // With prompting:
     application_is_trusted_with_prompt()
 }
+
+
+//example use
+//keys!(device_state, {
+//    Keycode::Escape => {return}, 
+//    _ => {break}
+//});
+
+#[macro_export] macro_rules! use_keys {
+    ($state:tt, {$($key:pat => $code:block),*}) => {
+        let keys: Vec<Keycode> = $state.get_keys();
+        for key in keys.iter() {   
+            match key {
+                $($key => {$code}),*,
+            }
+        }
+
+    };
+}
+


### PR DESCRIPTION
simplifies the code behind a match statement for the key vector to make adding simple keyboard commands simpler

i didnt test this on this specific project, but this is copy-pasted from another project that i tested it on so it should work fine (i also didnt want to break anything trying to test it). _hopefully_ this is the right place to put this, please lmk if i should move it somewhere else.