### PR TITLE
feat(event-loop): Add configurable sleep duration and decouple callback system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ travis-ci = { repository = "ostrosco/device_query" }
 pkg-config = "0.3.26"
 
 [dependencies]
-lazy_static = "1.4.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 x11 = {version = "2.21.0", features = ["xlib"] }

--- a/README.md
+++ b/README.md
@@ -37,3 +37,35 @@ backspace, et cetera. This is due to a permission issue. To work around this:
 * go to Security -> Privacy
 * scroll down to Accessibility and unlock it
 * add the app that is using `device_query` (such as your terminal) to the list
+
+# Device Callbacks
+
+`device_query` allows you to register callbacks for various device events such as key presses and mouse movements.
+
+## Example
+
+Here's a simple example demonstrating how to use the callback system:
+
+```rust
+extern crate device_query;
+use device_query::{DeviceEvents, DeviceEventsHandler, Keycode, MouseButton, MousePosition};
+use std::thread;
+use std::time::Duration;
+
+fn main() {
+    // Initialize the event handler with a sleep duration of 10 milliseconds
+    let event_handler = DeviceEventsHandler::new(Duration::from_millis(10))
+        .expect("Could not initialize event loop");
+
+    // Register callbacks for various events
+    // The callbacks will be automatically deregistered when they go out of scope
+    let _mouse_move_guard = event_handler.on_mouse_move(|position: &MousePosition| {
+        println!("Mouse moved to position: {:?}", position);
+    });
+
+    // Keep the main thread alive to continue receiving events
+    loop {
+        thread::sleep(Duration::from_secs(1000));
+    }
+}
+```

--- a/examples/event_based_print_keys.rs
+++ b/examples/event_based_print_keys.rs
@@ -1,15 +1,16 @@
 extern crate device_query;
 
-use device_query::{DeviceEvents, DeviceState};
+use device_query::{DeviceEvents, DeviceEventsHandler, DeviceState};
 use std::thread;
 use std::time::Duration;
 
 fn main() {
-    let device_state = DeviceState::new();
-    let _guard = device_state.on_key_down(|key| {
+    let event_handler = DeviceEventsHandler::new(Duration::from_millis(10))
+        .expect("Could not initialize event loop");
+    let _guard = event_handler.on_key_down(|key| {
         println!("Down: {:#?}", key);
     });
-    let _guard = device_state.on_key_up(|key| {
+    let _guard = event_handler.on_key_up(|key| {
         println!("Up: {:#?}", key);
     });
 

--- a/examples/event_based_print_keys.rs
+++ b/examples/event_based_print_keys.rs
@@ -1,6 +1,6 @@
 extern crate device_query;
 
-use device_query::{DeviceEvents, DeviceEventsHandler, DeviceState};
+use device_query::{DeviceEvents, DeviceEventsHandler};
 use std::thread;
 use std::time::Duration;
 

--- a/examples/event_based_print_mouse.rs
+++ b/examples/event_based_print_mouse.rs
@@ -1,18 +1,19 @@
 extern crate device_query;
 
-use device_query::{DeviceEvents, DeviceState};
+use device_query::{DeviceEvents, DeviceEventsHandler};
 use std::thread;
 use std::time::Duration;
 
 fn main() {
-    let device_state = DeviceState::new();
-    let _guard = device_state.on_mouse_move(|position| {
+    let event_handler = DeviceEventsHandler::new(std::time::Duration::from_millis(10))
+        .expect("Could not initialize event loop");
+    let _guard = event_handler.on_mouse_move(|position| {
         println!("Position: {:#?}", position);
     });
-    let _guard = device_state.on_mouse_down(|button| {
+    let _guard = event_handler.on_mouse_down(|button| {
         println!("Down: {:#?}", button);
     });
-    let _guard = device_state.on_mouse_up(|button| {
+    let _guard = event_handler.on_mouse_up(|button| {
         println!("Up: {:#?}", button);
     });
 

--- a/src/device_events/event_loop.rs
+++ b/src/device_events/event_loop.rs
@@ -129,7 +129,7 @@ impl EventLoop {
     }
 }
 
-pub static EVENT_LOOP: LazyLock<Mutex<Option<EventLoop>>> = LazyLock::new(|| Default::default());
+pub(crate) static EVENT_LOOP: LazyLock<Mutex<Option<EventLoop>>> = LazyLock::new(|| Default::default());
 
 pub(crate) fn init_event_loop(sleep_dur: Duration) -> bool {
     let Ok(mut lock) = EVENT_LOOP.lock() else {

--- a/src/device_events/mod.rs
+++ b/src/device_events/mod.rs
@@ -1,4 +1,27 @@
 //! Devices events listeners.
+//! 
+//! This module contains the implementation of the DeviceEventsHandler struct.
+//! This allows to register callbacks for device events.
+//! for the current state of the device, see the [`DeviceState`](crate::device_state::DeviceState) struct.
+//! 
+//! # Example
+//! 
+//! ```no_run
+//! use device_query::{DeviceEvents, DeviceEventsHandler, Keycode, MouseButton};
+//! 
+//! fn main() {
+//!   let device_events = DeviceEventsHandler::new().unwrap();
+//!   // Register a key down event callback
+//!   // The guard is used to keep the callback alive
+//!   let _guard = device_events.on_key_down(|key| {
+//!     println!("Key down: {:?}", key);
+//!   });
+//!   // Keep the main thread alive
+//!   loop {}
+//! }
+//! 
+//! ```
+//! 
 
 mod callback;
 mod event_loop;

--- a/src/device_events/mod.rs
+++ b/src/device_events/mod.rs
@@ -8,9 +8,10 @@
 //! 
 //! ```no_run
 //! use device_query::{DeviceEvents, DeviceEventsHandler, Keycode, MouseButton};
+//! use std::time::Duration;
 //! 
 //! fn main() {
-//!   let device_events = DeviceEventsHandler::new().unwrap();
+//!   let device_events = DeviceEventsHandler::new(Duration::from_millis(10)).unwrap();
 //!   // Register a key down event callback
 //!   // The guard is used to keep the callback alive
 //!   let _guard = device_events.on_key_down(|key| {

--- a/src/device_events/utils.rs
+++ b/src/device_events/utils.rs
@@ -13,12 +13,12 @@ impl<T> DrainFilter<T> for Vec<T> {
         F: FnMut(&mut T) -> bool,
     {
         let mut filter = filter;
-        let mut i = 0;
-        while i < self.len() {
+        let mut i = self.len() - 1;
+        while i > 0 {
             if filter(&mut self[i]) {
                 self.remove(i);
             } else {
-                i += 1;
+                i -= 1;
             }
         }
     }

--- a/src/device_events/utils.rs
+++ b/src/device_events/utils.rs
@@ -13,6 +13,9 @@ impl<T> DrainFilter<T> for Vec<T> {
         F: FnMut(&mut T) -> bool,
     {
         let mut filter = filter;
+        if self.len() == 0 {
+            return;
+        }
         let mut i = self.len() - 1;
         while i > 0 {
             if filter(&mut self[i]) {

--- a/src/device_state/mod.rs
+++ b/src/device_state/mod.rs
@@ -1,4 +1,21 @@
 //! DeviceState implementation.
+//! 
+//! This module contains the implementation of the DeviceState struct.
+//! This only allows to get the current state of the device.
+//! for callbacks, see the [`DeviceEventsHandler`](crate::device_events::DeviceEventsHandler) struct.
+//! 
+//! # Example
+//! 
+//! ```no_run
+//! use device_query::{DeviceState, DeviceQuery};
+//! 
+//! fn main() {
+//!   let device_state = DeviceState::new(); 
+//!   println!("Mouse position: {:?}", device_state.get_mouse());
+//!   println!("Key down: {:?}", device_state.get_keys());
+//! }
+//! 
+//! ```
 
 #[cfg(target_os = "linux")]
 mod linux;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,26 +15,17 @@
 //!
 //! It's also possible to listen for events.
 //! ```no_run
-//!  use device_query::{DeviceEvents, DeviceState};
+//!  use device_query::{DeviceEvents, DeviceEventsHandler};
 //!
-//!  let device_state = DeviceState::new();
+//!  let device_state = DeviceEventsHandler::new();
 //!
+//!  // Register a key down event callback
+//!  // The guard is used to keep the callback alive
 //!  let _guard = device_state.on_mouse_move(|position| {
 //!     println!("Mouse position: {:#?}", position);
 //!  });
-//!  let _guard = device_state.on_mouse_down(|button| {
-//!     println!("Mouse button down: {:#?}", button);
-//!  });
-//!  let _guard = device_state.on_mouse_up(|button| {
-//!     println!("Mouse button up: {:#?}", button);
-//!  });
-//!  let _guard = device_state.on_key_down(|key| {
-//!     println!("Keyboard key down: {:#?}", key);
-//!  });
-//!  let _guard = device_state.on_key_up(|key| {
-//!     println!("Keyboard key up: {:#?}", key);
-//!  });
 //!
+//!  // Keep the main thread alive
 //!  loop {}
 //! ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,10 @@
 //! It's also possible to listen for events.
 //! ```no_run
 //!  use device_query::{DeviceEvents, DeviceEventsHandler};
+//!  use std::time::Duration;
 //!
-//!  let device_state = DeviceEventsHandler::new();
+//!  let device_state = DeviceEventsHandler::new(Duration::from_millis(10))
+//!     .expect("Failed to start event loop");
 //!
 //!  // Register a key down event callback
 //!  // The guard is used to keep the callback alive
@@ -28,9 +30,6 @@
 //!  // Keep the main thread alive
 //!  loop {}
 //! ```
-
-#[macro_use]
-extern crate lazy_static;
 
 #[cfg(target_os = "windows")]
 extern crate windows;


### PR DESCRIPTION
Enhances the event loop system by introducing configurable sleep durations and separating the callback mechanism from the device query system for improved flexibility and performance control.
Key changes:
- Introduced `sleep_dur`: Duration parameter in EventLoop::new() to allow customizable polling intervals
- Implemented `init_event_loop` function that accepts sleep duration configuration
- Decoupled the callback system from device querying logic for independent operation

Breaking:
Users will now have to instantiate the `DeviceEventsHandler` instead of using the `DeviceState`, allowing for users to decide what part of the API they need to use. Rarely would a user need to both establish callbacks and query the devices from the same struct, and when they do it'd be simple to wrap both of the structs into one like so: 

```rust
struct QueryCallbackHandler {
   pub state: DeviceState,
   pub event_handler: DeviceEventHandler,
}
```

Rationale for decoupling:
The callback system and device querying serve fundamentally different purposes - one actively monitors for changes while the other provides point-in-time state information. Coupling these together forced unnecessary overhead when users only needed one capability. This separation allows each system to evolve independently and enables users to optimize their applications by only including the functionality they need.
