### PR TITLE
Update readkey dependency to 0.2.2 (fix for right-side modifier keys on macOS)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,6 @@ x11 = {version = "2.21.0", features = ["xlib"] }
 windows = {version = "0.48.0", features = ["Win32_UI_Input_KeyboardAndMouse", "Win32_UI_WindowsAndMessaging", "Win32_Foundation", "Win32_Foundation"]}
 
 [target.'cfg(target_os = "macos")'.dependencies]
-readkey = "0.2.1"
+readkey = "0.2.2"
 readmouse = "0.2.1"
 macos-accessibility-client = "0.0.1"

--- a/src/device_state/macos/mod.rs
+++ b/src/device_state/macos/mod.rs
@@ -88,6 +88,7 @@ const MAPPING: &[(readkey::Keycode, Keycode)] = &[
     (readkey::Keycode::Option, Keycode::LOption),
     (readkey::Keycode::RightOption, Keycode::ROption),
     (readkey::Keycode::Command, Keycode::Command),
+    (readkey::Keycode::RightCommand, Keycode::RCommand),
     (readkey::Keycode::Return, Keycode::Enter),
     (readkey::Keycode::Up, Keycode::Up),
     (readkey::Keycode::Down, Keycode::Down),

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -71,7 +71,9 @@ pub enum Keycode {
     RShift,
     LAlt,
     RAlt,
+    // TODO rename `Command` into `RCommand` at new major release
     Command,
+    RCommand,
     LOption,
     ROption,
     LMeta,
@@ -193,7 +195,9 @@ impl FromStr for Keycode {
             "RShift" => Ok(Self::RShift),
             "LAlt" => Ok(Self::LAlt),
             "RAlt" => Ok(Self::RAlt),
+            // TODO rename `Command` into `RCommand` at new major release
             "Command" => Ok(Self::Command),
+            "RCommand" => Ok(Self::RCommand),
             "LOption" => Ok(Self::LOption),
             "ROption" => Ok(Self::ROption),
             "LMeta" => Ok(Self::LMeta),


### PR DESCRIPTION
This PR updates the readkey dependency to version 0.2.2, which includes a fix for detecting right-side modifier keys (Shift, Ctrl, Command, Option) on macOS.

This update maintains backward compatibility, adding todos for futher major release.

resolves ostrosco/device_query#58